### PR TITLE
Фикс ошибок отправки сообщений в заблокированные чаты

### DIFF
--- a/app/Http/Services/MessagesService.php
+++ b/app/Http/Services/MessagesService.php
@@ -10,6 +10,8 @@ use Telegram\Bot\Objects\Message;
 
 class MessagesService
 {
+    private const FORBIDDEN_STATUS = 403;
+
     public function sendMessage(int $chatId, string $text, string $parseMode = 'HTML', bool $disablePagePreview = true): ?Message
     {
         try {
@@ -23,7 +25,7 @@ class MessagesService
                 return $message;
             }
         } catch (Exception $ex) {
-            if ($ex->getCode() == 403 && Chat::find($chatId)?->delete()) {
+            if ($ex->getCode() == self::FORBIDDEN_STATUS && Chat::find($chatId)?->delete()) {
                 Log::warning('Удален заблокированный чат', ['chatId' => $chatId]);
             } else {
                 Log::error('Ошибка отправки сообщения', ['text' => $text, 'exception' => $ex->getMessage()]);

--- a/app/Http/Services/MessagesService.php
+++ b/app/Http/Services/MessagesService.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Services;
 
+use App\Models\Chat;
 use Exception;
 use Illuminate\Support\Facades\Log;
 use Telegram\Bot\Laravel\Facades\Telegram;
@@ -22,7 +23,11 @@ class MessagesService
                 return $message;
             }
         } catch (Exception $ex) {
-            Log::error('Ошибка отправки сообщения', ['text' => $text, 'exception' => $ex->getMessage()]);
+            if ($ex->getCode() == 403 && Chat::find($chatId)?->delete()) {
+                Log::warning('Удален заблокированный чат', ['chatId' => $chatId]);
+            } else {
+                Log::error('Ошибка отправки сообщения', ['text' => $text, 'exception' => $ex->getMessage()]);
+            }
         }
 
         return null;

--- a/app/Models/Chat.php
+++ b/app/Models/Chat.php
@@ -20,4 +20,17 @@ class Chat extends Model
     {
         return $this->belongsToMany(User::class)->withPivot('id');
     }
+
+    protected static function booted(): void
+    {
+        static::deleting(function ($chat) {
+            $chat->users()->detach();
+
+            $usersToDelete = User::query()->doesntHave('chats')->get();
+
+            foreach ($usersToDelete as $user) {
+                $user->delete();
+            }
+        });
+    }
 }


### PR DESCRIPTION
Добавлена относительно костыльная проверка статуса отправки сообщений в ТГ чаты, если встречаем статус Forbidden (403) - удаляем чат

Дополнительно реализовал чистку таблицы пользователей. При удалении чата, если есть пользователи без закрепления в чатах - удаляем